### PR TITLE
Updated kdocs with generic and os-specific wording

### DIFF
--- a/kvault/src/androidMain/kotlin/com/liftric/kvault/KVault.kt
+++ b/kvault/src/androidMain/kotlin/com/liftric/kvault/KVault.kt
@@ -178,7 +178,7 @@ actual class KVault(private val context: Context) {
     }
 
     /**
-     * Deletes all objects with the service name from the shared preferences.
+     * Deletes all objects from the SharedPreferences.
      */
     actual fun clear() {
         encSharedPrefs.edit().clear().apply()

--- a/kvault/src/androidMain/kotlin/com/liftric/kvault/KVault.kt
+++ b/kvault/src/androidMain/kotlin/com/liftric/kvault/KVault.kt
@@ -19,6 +19,11 @@ actual class KVault(private val context: Context) {
         )
     }
 
+    /**
+     * Saves a string value in the shared preferences.
+     * @param key The key to store
+     * @param value The value to store
+     */
     actual fun set(key: String, value: String): Boolean {
         return encSharedPrefs
             .edit()
@@ -26,6 +31,11 @@ actual class KVault(private val context: Context) {
             .commit()
     }
 
+    /**
+     * Saves an int value in the shared preferences.
+     * @param key The key to store
+     * @param value The value to store
+     */
     actual fun set(key: String, value: Int): Boolean {
         return encSharedPrefs
             .edit()
@@ -33,6 +43,11 @@ actual class KVault(private val context: Context) {
             .commit()
     }
 
+    /**
+     * Saves a long value in the shared preferences.
+     * @param key The key to store
+     * @param value The value to store
+     */
     actual fun set(key: String, value: Long): Boolean {
         return encSharedPrefs
             .edit()
@@ -40,6 +55,11 @@ actual class KVault(private val context: Context) {
             .commit()
     }
 
+    /**
+     * Saves a float value in the shared preferences.
+     * @param key The key to store
+     * @param value The value to store
+     */
     actual fun set(key: String, value: Float): Boolean {
         return encSharedPrefs
             .edit()
@@ -47,6 +67,11 @@ actual class KVault(private val context: Context) {
             .commit()
     }
 
+    /**
+     * Saves a double value in the shared preferences.
+     * @param key The key to store
+     * @param value The value to store
+     */
     actual fun set(key: String, value: Double): Boolean {
         return encSharedPrefs
             .edit()
@@ -54,6 +79,11 @@ actual class KVault(private val context: Context) {
             .commit()
     }
 
+    /**
+     * Saves a boolean value in the shared preferences.
+     * @param key The key to store
+     * @param value The value to store
+     */
     actual fun set(key: String, value: Boolean): Boolean {
         return encSharedPrefs
             .edit()
@@ -61,14 +91,29 @@ actual class KVault(private val context: Context) {
             .commit()
     }
 
+    /**
+     * Checks if object with key exists in the shared preferences.
+     * @param forKey The key to query
+     * @return True or false, depending on wether it is in the shared preferences or not
+     */
     actual fun existsObject(forKey: String): Boolean {
         return encSharedPrefs.contains(forKey)
     }
 
+    /**
+     * Returns the string value of an object in the shared preferences.
+     * @param forKey The key to query
+     * @return The stored string value, or null if it is missing
+     */
     actual fun string(forKey: String): String? {
         return encSharedPrefs.getString(forKey, null)
     }
 
+    /**
+     * Returns the int value of an object in the shared preferences.
+     * @param forKey The key to query
+     * @return The stored string value, or null if it is missing
+     */
     actual fun int(forKey: String): Int? {
         if (existsObject(forKey)) {
             return encSharedPrefs.getInt(forKey, Int.MIN_VALUE)
@@ -76,6 +121,11 @@ actual class KVault(private val context: Context) {
         return null
     }
 
+    /**
+     * Returns the long value of an object in the shared preferences.
+     * @param forKey The key to query
+     * @return The stored string value, or null if it is missing
+     */
     actual fun long(forKey: String): Long? {
         if (existsObject(forKey)) {
             return encSharedPrefs.getLong(forKey, Long.MIN_VALUE)
@@ -83,13 +133,11 @@ actual class KVault(private val context: Context) {
         return null
     }
 
-    actual fun double(forKey: String): Double? {
-        if (existsObject(forKey)) {
-            return Double.fromBits(encSharedPrefs.getLong(forKey, Double.MIN_VALUE.toRawBits()))
-        }
-        return null
-    }
-
+    /**
+     * Returns the float value of an object in the shared preferences.
+     * @param forKey The key to query
+     * @return The stored string value, or null if it is missing
+     */
     actual fun float(forKey: String): Float? {
         if (existsObject(forKey)) {
             return encSharedPrefs.getFloat(forKey, Float.MIN_VALUE)
@@ -97,6 +145,23 @@ actual class KVault(private val context: Context) {
         return null
     }
 
+    /**
+     * Returns the double value of an object in the shared preferences.
+     * @param forKey The key to query
+     * @return The stored string value, or null if it is missing
+     */
+    actual fun double(forKey: String): Double? {
+        if (existsObject(forKey)) {
+            return Double.fromBits(encSharedPrefs.getLong(forKey, Double.MIN_VALUE.toRawBits()))
+        }
+        return null
+    }
+
+    /**
+     * Returns the boolean value of an object in the shared preferences.
+     * @param forKey The key to query
+     * @return The stored string value, or null if it is missing
+     */
     actual fun bool(forKey: String): Boolean? {
         if (existsObject(forKey)) {
             return encSharedPrefs.getBoolean(forKey, false)
@@ -104,10 +169,17 @@ actual class KVault(private val context: Context) {
         return null
     }
 
+    /**
+     * Deletes object with the given key from the shared preferences.
+     * @param forKey The key to query
+     */
     actual fun deleteObject(forKey: String): Boolean {
         return encSharedPrefs.edit().remove(forKey).commit()
     }
 
+    /**
+     * Deletes all objects with the service name from the shared preferences.
+     */
     actual fun clear() {
         encSharedPrefs.edit().clear().apply()
     }

--- a/kvault/src/commonMain/kotlin/com/liftric/kvault/KVault.kt
+++ b/kvault/src/commonMain/kotlin/com/liftric/kvault/KVault.kt
@@ -2,84 +2,84 @@ package com.liftric.kvault
 
 expect class KVault {
     /**
-     * Saves a string value in the keychain.
-     * @param key The key to query
+     * Saves a string value in the store.
+     * @param key The key to store
      * @param value The value to store
      */
     fun set(key: String, value: String): Boolean
 
     /**
-     * Saves an int value in the keychain.
-     * @param key The key to query
+     * Saves an int value in the store.
+     * @param key The key to store
      * @param value The value to store
      */
     fun set(key: String, value: Int): Boolean
 
     /**
-     * Saves a long value in the keychain.
-     * @param key The key to query
+     * Saves a long value in the store.
+     * @param key The key to store
      * @param value The value to store
      */
     fun set(key: String, value: Long): Boolean
 
     /**
-     * Saves a float value in the keychain.
-     * @param key The key to query
+     * Saves a float value in the store.
+     * @param key The key to store
      * @param value The value to store
      */
     fun set(key: String, value: Float): Boolean
 
     /**
-     * Saves a double value in the keychain.
-     * @param key The key to query
+     * Saves a double value in the store.
+     * @param key The key to store
      * @param value The value to store
      */
     fun set(key: String, value: Double): Boolean
 
     /**
-     * Saves a boolean value in the keychain.
-     * @param key The key to query
+     * Saves a boolean value in the store.
+     * @param key The key to store
      * @param value The value to store
      */
     fun set(key: String, value: Boolean): Boolean
 
     /**
-     * Checks if object with key exists in the keychain.
+     * Checks if object with key exists in the store.
      * @param forKey The key to query
-     * @return True or false, depending on wether it is in the keychain or not
+     * @return True or false, depending on wether it is in the store or not
      */
     fun existsObject(forKey: String): Boolean
 
     /**
-     * Returns the string value of an object in the keychain.
+     * Returns the string value of an object in the store.
      * @param forKey The key to query
      * @return The stored string value
      */
     fun string(forKey: String): String?
 
     /**
-     * Returns the int value of an object in the keychain.
+     * Returns the int value of an object in the store.
      * @param forKey The key to query
      * @return The stored int value
      */
     fun int(forKey: String): Int?
 
     /**
-     * Returns the long value of an object in the keychain.
+     * Returns the long value of an object in the store.
      * @param forKey The key to query
      * @return The stored long value
      */
     fun long(forKey: String): Long?
 
     /**
-     * Returns the int value of an object in the keychain.
+     * Returns the double value of an object in the store.
      * @param forKey The key to query
      * @return The stored double lue
      */
     fun double(forKey: String): Double?
 
     /**
-     * Returns the int value of an object in the keychain.
+     * Returns the float value of an object in the store.
      * @param forKey The key to query
      * @return The stored float value
      */
@@ -93,13 +93,13 @@ expect class KVault {
     fun bool(forKey: String): Boolean?
 
     /**
-     * Deletes object with the given key from the keychain.
+     * Deletes object with the given key from the store.
      * @param forKey The key to query
      */
     fun deleteObject(forKey: String): Boolean
 
     /**
-     * Deletes all objects with the service name from the keychain.
+     * Deletes all objects with the service name from the store.
      */
     fun clear()
 }

--- a/kvault/src/iosMain/kotlin/com/liftric/kvault/KVault.kt
+++ b/kvault/src/iosMain/kotlin/com/liftric/kvault/KVault.kt
@@ -24,7 +24,7 @@ actual class KVault() {
     // ===============
 
     /**
-     * Saves a string value in the keychain.
+     * Saves a string value in the Keychain.
      * @param key The key to store
      * @param value The value to store
      */
@@ -36,7 +36,7 @@ actual class KVault() {
     }
 
     /**
-     * Saves an int value in the keychain.
+     * Saves an int value in the Keychain.
      * @param key The key to store
      * @param value The value to store
      */
@@ -46,7 +46,7 @@ actual class KVault() {
     }
 
     /**
-     * Saves a long value in the keychain.
+     * Saves a long value in the Keychain.
      * @param key The key to store
      * @param value The value to store
      */
@@ -56,7 +56,7 @@ actual class KVault() {
     }
 
     /**
-     * Saves a float value in the keychain.
+     * Saves a float value in the Keychain.
      * @param key The key to store
      * @param value The value to store
      */
@@ -66,7 +66,7 @@ actual class KVault() {
     }
 
     /**
-     * Saves a double value in the keychain.
+     * Saves a double value in the Keychain.
      * @param key The key to store
      * @param value The value to store
      */
@@ -76,7 +76,7 @@ actual class KVault() {
     }
 
     /**
-     * Saves a boolean value in the keychain.
+     * Saves a boolean value in the Keychain.
      * @param key The key to store
      * @param value The value to store
      */
@@ -90,7 +90,7 @@ actual class KVault() {
     // ===============
 
     /**
-     * Returns the string value of an object in the keychain.
+     * Returns the string value of an object in the Keychain.
      * @param forKey The key to query
      * @return The stored string value, or null if it is missing
      */
@@ -103,7 +103,7 @@ actual class KVault() {
     }
 
     /**
-     * Returns the int value of an object in the keychain.
+     * Returns the int value of an object in the Keychain.
      * @param forKey The key to query
      * @return The stored string value, or null if it is missing
      */
@@ -117,7 +117,7 @@ actual class KVault() {
     }
 
     /**
-     * Returns the long value of an object in the keychain.
+     * Returns the long value of an object in the Keychain.
      * @param forKey The key to query
      * @return The stored string value, or null if it is missing
      */
@@ -131,7 +131,7 @@ actual class KVault() {
     }
 
     /**
-     * Returns the float value of an object in the keychain.
+     * Returns the float value of an object in the Keychain.
      * @param forKey The key to query
      * @return The stored string value, or null if it is missing
      */
@@ -145,7 +145,7 @@ actual class KVault() {
     }
 
     /**
-     * Returns the double value of an object in the keychain.
+     * Returns the double value of an object in the Keychain.
      * @param forKey The key to query
      * @return The stored string value, or null if it is missing
      */
@@ -159,7 +159,7 @@ actual class KVault() {
     }
 
     /**
-     * Returns the boolean value of an object in the keychain.
+     * Returns the boolean value of an object in the Keychain.
      * @param forKey The key to query
      * @return The stored string value, or null if it is missing
      */
@@ -173,7 +173,7 @@ actual class KVault() {
     }
 
     /**
-     * Checks if object with key exists in the keychain.
+     * Checks if object with the given key exists in the Keychain.
      * @param forKey The key to query
      * @return True or false, depending on wether it is in the shared preferences or not
      */
@@ -199,7 +199,7 @@ actual class KVault() {
     // ==================
 
     /**
-     * Deletes object with the given key from the keychain.
+     * Deletes object with the given key from the Keychain.
      * @param forKey The key to query
      */
     actual fun deleteObject(forKey: String): Boolean {
@@ -211,7 +211,7 @@ actual class KVault() {
     }
 
     /**
-     * Deletes all objects with the service name from the keychain.
+     * Deletes all objects with the service name from the Keychain.
      */
     actual fun clear() {
         val query = CFDictionaryCreateMutable(null, capacity(2), null, null)

--- a/kvault/src/iosMain/kotlin/com/liftric/kvault/KVault.kt
+++ b/kvault/src/iosMain/kotlin/com/liftric/kvault/KVault.kt
@@ -23,6 +23,11 @@ actual class KVault() {
     // SET OPERATIONS
     // ===============
 
+    /**
+     * Saves a string value in the keychain.
+     * @param key The key to store
+     * @param value The value to store
+     */
     actual fun set(key: String, value: String): Boolean {
         @Suppress("CAST_NEVER_SUCCEEDS")
         (value as NSString).dataUsingEncoding(NSUTF8StringEncoding)?.let {
@@ -30,26 +35,51 @@ actual class KVault() {
         } ?: run { return false }
     }
 
+    /**
+     * Saves an int value in the keychain.
+     * @param key The key to store
+     * @param value The value to store
+     */
     actual fun set(key: String, value: Int): Boolean {
         val number = NSNumber.numberWithInt(value)
         return set(key, NSKeyedArchiver.archivedDataWithRootObject(number))
     }
 
+    /**
+     * Saves a long value in the keychain.
+     * @param key The key to store
+     * @param value The value to store
+     */
     actual fun set(key: String, value: Long): Boolean {
         val number = NSNumber.numberWithLong(value)
         return set(key, NSKeyedArchiver.archivedDataWithRootObject(number))
     }
 
+    /**
+     * Saves a float value in the keychain.
+     * @param key The key to store
+     * @param value The value to store
+     */
     actual fun set(key: String, value: Float): Boolean {
         val number = NSNumber.numberWithFloat(value)
         return set(key, NSKeyedArchiver.archivedDataWithRootObject(number))
     }
 
+    /**
+     * Saves a double value in the keychain.
+     * @param key The key to store
+     * @param value The value to store
+     */
     actual fun set(key: String, value: Double): Boolean {
         val number = NSNumber.numberWithDouble(value)
         return set(key, NSKeyedArchiver.archivedDataWithRootObject(number))
     }
 
+    /**
+     * Saves a boolean value in the keychain.
+     * @param key The key to store
+     * @param value The value to store
+     */
     actual fun set(key: String, value: Boolean): Boolean {
         val number = NSNumber.numberWithBool(value)
         return set(key, NSKeyedArchiver.archivedDataWithRootObject(number))
@@ -59,6 +89,11 @@ actual class KVault() {
     // GET OPERATIONS
     // ===============
 
+    /**
+     * Returns the string value of an object in the keychain.
+     * @param forKey The key to query
+     * @return The stored string value, or null if it is missing
+     */
     actual fun string(forKey: String): String? {
         data(forKey)?.let { data ->
             return NSString.create(data, NSUTF8StringEncoding) as String?
@@ -67,6 +102,11 @@ actual class KVault() {
         }
     }
 
+    /**
+     * Returns the int value of an object in the keychain.
+     * @param forKey The key to query
+     * @return The stored string value, or null if it is missing
+     */
     actual fun int(forKey: String): Int? {
         data(forKey)?.let {
             val number = NSKeyedUnarchiver.unarchiveObjectWithData(it) as NSNumber
@@ -76,6 +116,11 @@ actual class KVault() {
         }
     }
 
+    /**
+     * Returns the long value of an object in the keychain.
+     * @param forKey The key to query
+     * @return The stored string value, or null if it is missing
+     */
     actual fun long(forKey: String): Long? {
         data(forKey)?.let {
             val number = NSKeyedUnarchiver.unarchiveObjectWithData(it) as NSNumber
@@ -85,6 +130,11 @@ actual class KVault() {
         }
     }
 
+    /**
+     * Returns the float value of an object in the keychain.
+     * @param forKey The key to query
+     * @return The stored string value, or null if it is missing
+     */
     actual fun float(forKey: String): Float? {
         data(forKey)?.let {
             val number = NSKeyedUnarchiver.unarchiveObjectWithData(it) as NSNumber
@@ -94,6 +144,11 @@ actual class KVault() {
         }
     }
 
+    /**
+     * Returns the double value of an object in the keychain.
+     * @param forKey The key to query
+     * @return The stored string value, or null if it is missing
+     */
     actual fun double(forKey: String): Double? {
         data(forKey)?.let {
             val number = NSKeyedUnarchiver.unarchiveObjectWithData(it) as NSNumber
@@ -103,6 +158,11 @@ actual class KVault() {
         }
     }
 
+    /**
+     * Returns the boolean value of an object in the keychain.
+     * @param forKey The key to query
+     * @return The stored string value, or null if it is missing
+     */
     actual fun bool(forKey: String): Boolean? {
         data(forKey)?.let {
             val number = NSKeyedUnarchiver.unarchiveObjectWithData(it) as NSNumber
@@ -112,6 +172,11 @@ actual class KVault() {
         }
     }
 
+    /**
+     * Checks if object with key exists in the keychain.
+     * @param forKey The key to query
+     * @return True or false, depending on wether it is in the shared preferences or not
+     */
     actual fun existsObject(forKey: String): Boolean {
         val query = CFDictionaryCreateMutable(null, capacity(4), null, null)
         CFDictionaryAddValue(query, kSecClass, kSecClassGenericPassword)
@@ -133,6 +198,10 @@ actual class KVault() {
     // DELETE OPERATIONS
     // ==================
 
+    /**
+     * Deletes object with the given key from the keychain.
+     * @param forKey The key to query
+     */
     actual fun deleteObject(forKey: String): Boolean {
         val query = CFDictionaryCreateMutable(null, capacity(3), null, null)
         CFDictionaryAddValue(query, kSecClass, kSecClassGenericPassword)
@@ -141,6 +210,9 @@ actual class KVault() {
         return perform(Operation.Delete, query)
     }
 
+    /**
+     * Deletes all objects with the service name from the keychain.
+     */
     actual fun clear() {
         val query = CFDictionaryCreateMutable(null, capacity(2), null, null)
         CFDictionaryAddValue(query, kSecClass, kSecClassGenericPassword)


### PR DESCRIPTION
This solves #18 by using "store" as a generic term for the Kdoc in /commonMain and adds os-specific Kdoc for android and iOS, changing the wording to use "shared preferences" and "keychain" respectively.

It also fixes a couple of typos.