### PR TITLE
Bumped androidx.security:security-crypto to 1.1.0-alpha05

### DIFF
--- a/buildSrc/src/main/java/Libs.kt
+++ b/buildSrc/src/main/java/Libs.kt
@@ -9,7 +9,7 @@ object Versions {
     const val Gradle = "7.1.2"
     const val Kotlin = "1.6.20"
     const val Versioning = "2.15.1"
-    const val Crypto = "1.1.0-alpha03"
+    const val Crypto = "1.1.0-alpha05"
     const val RoboElectric = "4.5.1"
     const val TestCore = "1.4.0"
 }


### PR DESCRIPTION
Change log: https://developer.android.com/jetpack/androidx/releases/security?authuser=1#1.1.0-alpha05 


It should fix issue: https://issuetracker.google.com/issues/164901843

issues from this repo: https://github.com/Liftric/KVault/issues/14