### PR TITLE
Add support for storing raw binary data in the Vault.

### DIFF
--- a/src/androidMain/kotlin/com/liftric/kvault/KVault.kt
+++ b/src/androidMain/kotlin/com/liftric/kvault/KVault.kt
@@ -2,6 +2,7 @@ package com.liftric.kvault
 
 import android.content.Context
 import android.content.SharedPreferences
+import android.util.Base64
 import androidx.security.crypto.EncryptedSharedPreferences
 import androidx.security.crypto.MasterKey
 
@@ -98,6 +99,17 @@ actual open class KVault(context: Context, fileName: String? = null) {
     }
 
     /**
+     * Saves a byte array value in the store.
+     * @param key The key to store
+     * @param dataValue The value to store
+     */
+    actual fun set(key: String, dataValue: ByteArray): Boolean =
+        encSharedPrefs
+            .edit()
+            .putString(key, Base64.encodeToString(dataValue, Base64.DEFAULT))
+            .commit()
+
+    /**
      * Checks if object with key exists in the SharedPreferences.
      * @param forKey The key to query
      * @return True or false, depending on whether the value has been stored in the SharedPreferences
@@ -177,6 +189,17 @@ actual open class KVault(context: Context, fileName: String? = null) {
             encSharedPrefs.getBoolean(forKey, false)
         } else {
             null
+        }
+    }
+
+    /**
+     * Returns the data value of an object in the store.
+     * @param forKey The key to query
+     * @return The stored bytes value
+     */
+    actual fun data(forKey: String): ByteArray? {
+        return encSharedPrefs.getString(forKey, null)?.let {
+            Base64.decode(it, Base64.DEFAULT)
         }
     }
 

--- a/src/commonMain/kotlin/com/liftric/kvault/KVault.kt
+++ b/src/commonMain/kotlin/com/liftric/kvault/KVault.kt
@@ -44,6 +44,13 @@ expect open class KVault {
     fun set(key: String, boolValue: Boolean): Boolean
 
     /**
+     * Saves a byte array value in the store.
+     * @param key The key to store
+     * @param dataValue The value to store
+     */
+    fun set(key: String, dataValue: ByteArray): Boolean
+
+    /**
      * Checks if object with key exists in the store.
      * @param forKey The key to query
      * @return True or false, depending on wether it is in the store or not
@@ -91,6 +98,13 @@ expect open class KVault {
      * @return The stored boolean value
      */
     fun bool(forKey: String): Boolean?
+
+    /**
+     * Returns the data value of an object in the store.
+     * @param forKey The key to query
+     * @return The stored bytes value
+     */
+    fun data(forKey: String): ByteArray?
 
     /**
      * Returns all keys of the stored objects.

--- a/src/commonTest/kotlin/com/liftric/kvault/KVaultTest.kt
+++ b/src/commonTest/kotlin/com/liftric/kvault/KVaultTest.kt
@@ -157,6 +157,23 @@ abstract class AbstractKVaultTest(private val keychain: KVault) {
     }
 
     @Test
+    fun testSetGetData() {
+        val testData = mapOf(
+            "data1" to "Hello World!".encodeToByteArray(),
+            "data2" to "Foo bar".encodeToByteArray(),
+            "data3" to "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.".encodeToByteArray()
+        )
+        testData.values.toTypedArray().last() // - Why this line?
+        testData.forEach {
+            keychain.set(it.key, it.value)
+            assertContentEquals(it.value, keychain.data(it.key), "${it.key} should resolve to ${it.value.decodeToString()}")
+        }
+        funnelAssertion<ByteArray>(testData.keys.toList()) {
+            keychain.data(it)
+        }
+    }
+
+    @Test
     fun testSetGetAll() {
         val boolData = Pair("bool", true)
         keychain.set(boolData.first, boolData.second)


### PR DESCRIPTION
- Native support on iOS through the Keychain APIs.
- Support on Android through base64 encoding data to a string.

Closes #44 